### PR TITLE
Replace create-react-app default content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-app",
+  "name": "lastfm-stats",
   "version": "0.1.0",
   "private": true,
   "homepage": "https://davidomarf.github.io/lastfm",

--- a/public/index.html
+++ b/public/index.html
@@ -19,20 +19,10 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Last.fm Stats</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Last.fm Stats",
+  "name": "Last.fm Statistics Visualizations",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
## Description
`create-react-app` generates an example app with default fields, and they were never replaced, making the app still be named "React App".

This fixes all (I think) but one default values: the favicon.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code maintainance (non-breaking change that makes existing code better)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
As this is an update that only modifies documents, it has no effect on the functionality.