### PR TITLE
Prevent tooltip from going offscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ the app functionality.
 - Create a form to ask for the username to fetch
 - Get a list of all the scrobbles from the user in `user/:user`
 - Display a Heatmap of the last year (Today but one year ago, today)
+### Fixed
+- Tooltip no longer goes offscreen but instead now flips to the left
 #### Meta
 - Create a basic GitHub repository
 - Add community files: templates, contributing, code of conduct.

--- a/src/Visualizations/Heatmap.js
+++ b/src/Visualizations/Heatmap.js
@@ -19,16 +19,16 @@ var mouseover = function(d) {
 var mousemove = function(d) {
   let day = d3.select(this);
   tooltip_text
-    .attr("x", d3.mouse(this)[0] + 15)
-    .attr("y", d3.mouse(this)[1])
     .style("fill", "white")
+    .text(`${day.attr("scrobbles")} scrobbles on ${day.attr("date")}`)
     .attr("class", styles["meta-text"])
-    .text(`${day.attr("scrobbles")} scrobbles on ${day.attr("date")}`);
-  tooltip
-    .attr("x", d3.mouse(this)[0] + 10)
-    .attr("y", d3.mouse(this)[1] - 10)
+    .attr("x", d3.mouse(this)[0] + ((d3.mouse(this)[0] > 491) ? - (tooltip_text.node().getBBox().width  + 15): 15))
+    .attr("y", d3.mouse(this)[1]);
+    tooltip
     .attr("width", tooltip_text.node().getBBox().width + 10)
-    .attr("height", 15);
+    .attr("height", 15)
+    .attr("x", d3.mouse(this)[0] + ((d3.mouse(this)[0] > 491) ? - (tooltip_text.node().getBBox().width  + 20): 10))
+    .attr("y", d3.mouse(this)[1] - 10);
 };
 
 var mouseleave = function(d) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When the cursor hovered over dates near the edge, the tooltip tended to go offscreen.  I fixed that by putting the tooltip to the left of the cursor when the cursor was too close to the right edge.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I could not read the whole tooltip because it was cut off.  This fix solves the issue of the tooltip going offscreen.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I hovered over multiple days across both sides of the heatmap to check that the tooltip showed properly.  I tested it on chrome on gentoo linux as well as on windows with chrome and edge. The only thing my code affects is how the tooltip is shown.  I used various window sizes while testing it.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/30319043/60303064-10591e80-98fb-11e9-93b9-8fef672fede0.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code maintainance (non-breaking change that makes existing code better)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
