### PR TITLE
Contain all last.fm API related functions to its own file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ modifying templates, will be under the heading *Meta*. These changes don't affec
 the app functionality.
 
 ## [Unreleased]
+### Changed
+- Draw Heatmap incrementally, updating every time UserPage fetches another page of scrobbles
+- The days in the Heatmap graph, have an id based on the date they display (previously)
+  it was based on the days elapsed since the start of the displayed period.
 
 ## [0.1.0] - 2019-06-26
 ### Added

--- a/src/API/lastfm.js
+++ b/src/API/lastfm.js
@@ -4,40 +4,41 @@ const lastFmAPI = process.env.REACT_APP_LAST_FM_API;
 const lastFmCall =
   "https://ws.audioscrobbler.com/2.0/?format=json&api_key=" + lastFmAPI;
 
-async function getData(url, f) {
+
+async function getData(url) {
   try {
     const response = await axios.get(url);
-    const data = response.data;
-    let value;
-    f === undefined ? (value = data) : (value = f(data));
-    return value;
+    return response.data;
   } catch (error) {
     console.log(error);
   }
 }
 
-function getScrobbles(user) {
-  let pages = Math.ceil(user.playCount / 200);
-  let url = `${lastFmCall}&method=user.getrecenttracks&limit=200&user=${
-    this.state.user
-  }&page=`;
-  let scrobblesPromises = [];
-  let scrobbles = [];
-  for (let i = 1; i <= pages; i++) {
-    const returnRecentTracks = e => {
-      if (e.recenttracks.track[0]["@attr"]) {
-        e.recenttracks.track.shift();
-      }
-      return e.recenttracks.track;
-    };
-    scrobblesPromises.push(getData(`${url}${i}`, returnRecentTracks));
-  }
-  Promise.all(scrobblesPromises).then(values => {
-    scrobbles = scrobbles.concat(...values);
-    this.setState({
-      scrobbles: scrobbles
-    });
-  });
+// Exported functions used in UserPage
+
+/**
+ * Returns the number of scrobbles the user has
+ * @param {string} user Last.fm user
+ * @returns {Promise} Response to the method https://www.last.fm/api/show/user.getInfo
+ */
+function getUserPlayCount(user) {
+  let playCount = getData(lastFmCall + "&method=user.getinfo&user=" + user);
+  return playCount;
 }
 
-export default getData;
+/**
+ * Returns the specified page from the user's scrobble list. Each page has 200 entries.
+ * @param {string} user 
+ * @param {number} page Page of the
+ * @returns {Promise} Response to the method https://www.last.fm/api/show/user.getRecentTracks
+ */
+function getScrobbles(user, page) {
+  return getData(
+    `${lastFmCall}&method=user.getrecenttracks&limit=200&user=${user}&page=${page}`
+  );
+}
+
+module.exports = {
+  getScrobbles,
+  getUserPlayCount
+};

--- a/src/Pages/Userpage.jsx
+++ b/src/Pages/Userpage.jsx
@@ -5,32 +5,7 @@ import ReactFullpage from "@fullpage/react-fullpage";
 
 import Heatmap from "../Visualizations/Heatmap";
 
-// Include it to manage API requests without exceeding API call limit
-const axios = require("axios");
-
-// API base call. Append an API method. Know them at https://www.last.fm/api/intro
-const lastFmCall =
-  "https://ws.audioscrobbler.com/2.0/?format=json&api_key=" +
-  process.env.REACT_APP_LAST_FM_API;
-
-// TODO: Move this to ../API/lastfm.js
-/**
- * Fetch the data from one URL and apply (if provided) a function
- * to the data before returning it.
- *
- * @param {string} url URL to make the request
- * @param {function} [f] function to apply to the data before returning
- */
-const getData = async (url, f) => {
-  try {
-    const response = await axios.get(url);
-    let data = response.data;
-    if (f !== undefined) data = f(data);
-    return data;
-  } catch (error) {
-    console.log(error);
-  }
-};
+import lastfm from "../API/lastfm";
 
 /**
  * Whole page for the user rendered when route is /user/:user
@@ -41,60 +16,59 @@ class UserPage extends React.Component {
 
     this.state = {
       // Set user to the string after /user/ in the url
-      user: props.match.params.user
+      user: props.match.params.user,
+      playcount: 0,
+      scrobbles: []
     };
 
-    // Get the playcount of the user
-    fetch(lastFmCall + "&method=user.getinfo&user=" + this.state.user)
-      .then(res => res.json())
-      .then(data => {
-        this.setState({
-          playCount: data.user.playcount
-        });
-        // After setting the playCount for the user, get all the scrobblss
-        this.setScrobbles();
-      })
-      .catch(console.log);
+    // Get the actual playcount of the user
+    this.getPlaycount();
   }
 
   /**
-   *  Get all the scrobbles from the user
+   * Update the state of the component to contain the complete list of scrobbles
    */
-  setScrobbles() {
-    // Calculate the number of pages to fetch using playCount.
-    // Last.fm getrecenttracks has a maximum limit of 200.
+  getScrobbles() {
+    // Last.fm getrecenttracks has a limit of 200 items per page.
     // https://www.last.fm/api/show/user.getRecentTracks
-    let pages = Math.ceil(this.state.playCount / 200);
-    let url = `${lastFmCall}&method=user.getrecenttracks&limit=200&user=${
-      this.state.user
-    }&page=`;
+    let pages = Math.ceil(this.state.playcount / 200);
 
-    // Save all the promises from fetching the urls asynchronously
-    let scrobblesPromises = [];
-    // Array to contain the resolved promises
-    let scrobbles = [];
+    // Function to filter the value of the promise and return only what we'll be using
+    const returnRecentTracks = e => {
+      // If the user is currently scrobbling, delete that element
+      if (e.recenttracks.track[0]["@attr"]) {
+        e.recenttracks.track.shift();
+      }
+      return e.recenttracks.track;
+    };
 
     for (let i = 1; i <= pages; i++) {
-      // Function to send to getData.
-      // If the user is currently scrobbling, delete that element
-      const returnRecentTracks = e => {
-        // When a track is playing now, it has an .@attr property
-        if (e.recenttracks.track[0]["@attr"]) {
-          e.recenttracks.track.shift();
-        }
-        return e.recenttracks.track;
-      };
-      scrobblesPromises.push(getData(`${url}${i}`, returnRecentTracks));
+      // lastfm.getScrobbles() returns a Promise
+      lastfm
+        .getScrobbles(this.state.user, i)
+        // When resolved, update the state by concatenating the value of the promise
+        .then(v =>
+          this.setState({
+            scrobbles: this.state.scrobbles.concat(...returnRecentTracks(v))
+          })
+        );
     }
+  }
 
-    // When all the promises are resolved, add the values from each call
-    // to the scrobbles array.
-    Promise.all(scrobblesPromises).then(values => {
-      scrobbles = scrobbles.concat(...values);
-      this.setState({
-        scrobbles: scrobbles
-      });
-    });
+  /**
+   * Update the state of the component to contain the number of scrobbles from the user
+   */
+  getPlaycount() {
+    // lastfm.getUserPlayCount() returns a Promise
+    lastfm
+      .getUserPlayCount(this.state.user)
+      // When resolved, set the state using the value of the promise, and send
+      // a callback to get the scrobbles
+      .then(v =>
+        this.setState({ playcount: Number(v.user.playcount) }, () =>
+          this.getScrobbles()
+        )
+      );
   }
 
   render() {

--- a/src/Pages/Userpage.jsx
+++ b/src/Pages/Userpage.jsx
@@ -47,11 +47,21 @@ class UserPage extends React.Component {
       lastfm
         .getScrobbles(this.state.user, i)
         // When resolved, update the state by concatenating the value of the promise
-        .then(v =>
-          this.setState({
-            scrobbles: this.state.scrobbles.concat(...returnRecentTracks(v))
-          })
-        );
+        .then(v => {
+          if (v) {
+            let list = returnRecentTracks(v);
+            this.setState({
+              scrobbles: this.state.scrobbles.concat({
+                page: i,
+                list: list,
+                start: Number(list[list.length - 1].date.uts),
+                end: Number(list[0].date.uts)
+              })
+            });
+          } else {
+            console.log(i);
+          }
+        });
     }
   }
 


### PR DESCRIPTION
## Description
There used to be some files in src that made direct calls to `http://ws.audioscrobbler.com/2.0/`. Now they're all contained in `src/API/lastfm.js`.

This allowed a more organized way to fill the scrobbles list for the user, which in turn allowed the Heatmap component to be rendered incrementally, updating every time new scrobbles are added to the list.

Heatmap now doesn't work on the assumption that the scrobbles list is in order.

## Motivation and Context
Originally started as a solution to #1 
Even if not solved yet, it is easier to do it now that one single call rejected doesn't stop the app. And makes sense to merge.

## How Has This Been Tested?
Not as thoroughly as I'd like.
- During the development, API calls were rejected and the app kept running anyways, meaning that the idea of isolating data-fetching and data-processing worked.
- When the scrobble library is big, you can notice how Heatmap is being updated in real time.
- Logically, the new structure of Heatmap makes sense. (If that's a test)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code maintainance (non-breaking change that makes existing code better)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
