### PR TITLE
Replace import {} from "" with const {} = require ""

### DIFF
--- a/src/Pages/Userpage.jsx
+++ b/src/Pages/Userpage.jsx
@@ -5,7 +5,7 @@ import ReactFullpage from "@fullpage/react-fullpage";
 
 import Heatmap from "../Visualizations/Heatmap";
 
-import lastfm from "../API/lastfm";
+const lastfm = require("../API/lastfm");
 
 /**
  * Whole page for the user rendered when route is /user/:user


### PR DESCRIPTION
This should fix Heroku failed build log:
./src/Pages/Userpage.jsx
   Attempted import error: '../API/lastfm' does not
   contain a default export (imported as 'lastfm').