### PR TITLE
Scrobble fetching is done before data visualization

### DIFF
--- a/src/Elements/Loading.jsx
+++ b/src/Elements/Loading.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+/**
+ * Displays and handles the form to get the last.fm username
+ */
+function Loading(props) {
+  return (
+    <>
+      <h2>We are reading your scrobbles</h2>
+      <h3>
+        {props.pages} out of {props.total} pages
+      </h3>
+      <p>
+        You can go for a snack, we'll take about{" "}
+        {Math.round((props.total - props.pages) / 5)} seconds
+      </p>
+    </>
+  );
+}
+
+export default Loading;

--- a/src/Pages/Userpage.jsx
+++ b/src/Pages/Userpage.jsx
@@ -23,6 +23,17 @@ class UserPage extends React.Component {
       scrobbles: []
     };
 
+    this.endDate = { date: new Date() };
+    this.endDate.utc = Math.ceil(this.endDate.date.getTime() / 1000);
+
+    // Same day as endDate, but one year ago
+    this.startDate = {
+      date: new Date(
+        new Date().setFullYear(this.endDate.date.getFullYear() - 1)
+      )
+    };
+    this.startDate.utc = Math.floor(this.startDate.date.getTime() / 1000);
+
     // Get the actual playcount of the user
     this.getPlaycount();
   }
@@ -48,12 +59,14 @@ class UserPage extends React.Component {
         .then(v => {
           if (v) {
             let list = returnRecentTracks(v);
+            let start = Number(list[list.length - 1].date.uts);
+            let end = Number(list[0].date.uts);
             this.setState({
               scrobbles: this.state.scrobbles.concat({
                 page: i,
                 list: list,
-                start: Number(list[list.length - 1].date.uts),
-                end: Number(list[0].date.uts)
+                start: start,
+                end: end
               })
             });
           } else {
@@ -94,7 +107,10 @@ class UserPage extends React.Component {
                 <div className={styles["section-container"]}>
                   {/* Mount Heatmap only when the scrobbles are set */}
                   {this.state.scrobbles.length < this.state.pages && (
-                    <Loading pages={this.state.scrobbles.length} total={this.state.pages} />
+                    <Loading
+                      pages={this.state.scrobbles.length}
+                      total={this.state.pages}
+                    />
                   )}
                   {this.state.scrobbles.length >= this.state.pages && (
                     <Heatmap title="Heatmap" user={this.state} />

--- a/src/Pages/Userpage.jsx
+++ b/src/Pages/Userpage.jsx
@@ -4,6 +4,7 @@ import styles from "./Userpage.module.scss";
 import ReactFullpage from "@fullpage/react-fullpage";
 
 import Heatmap from "../Visualizations/Heatmap";
+import Loading from "../Elements/Loading";
 
 import lastfm from "../API/lastfm";
 
@@ -18,6 +19,7 @@ class UserPage extends React.Component {
       // Set user to the string after /user/ in the url
       user: props.match.params.user,
       playcount: 0,
+      pages: 1,
       scrobbles: []
     };
 
@@ -29,10 +31,6 @@ class UserPage extends React.Component {
    * Update the state of the component to contain the complete list of scrobbles
    */
   getScrobbles() {
-    // Last.fm getrecenttracks has a limit of 200 items per page.
-    // https://www.last.fm/api/show/user.getRecentTracks
-    let pages = Math.ceil(this.state.playcount / 200);
-
     // Function to filter the value of the promise and return only what we'll be using
     const returnRecentTracks = e => {
       // If the user is currently scrobbling, delete that element
@@ -42,7 +40,7 @@ class UserPage extends React.Component {
       return e.recenttracks.track;
     };
 
-    for (let i = 1; i <= pages; i++) {
+    for (let i = 1; i <= this.state.pages; i++) {
       // lastfm.getScrobbles() returns a Promise
       lastfm
         .getScrobbles(this.state.user, i)
@@ -75,8 +73,12 @@ class UserPage extends React.Component {
       // When resolved, set the state using the value of the promise, and send
       // a callback to get the scrobbles
       .then(v =>
-        this.setState({ playcount: Number(v.user.playcount) }, () =>
-          this.getScrobbles()
+        this.setState(
+          {
+            playcount: Number(v.user.playcount),
+            pages: Math.ceil(Number(v.user.playcount) / 200)
+          },
+          () => this.getScrobbles()
         )
       );
   }
@@ -91,7 +93,10 @@ class UserPage extends React.Component {
               <div className="section">
                 <div className={styles["section-container"]}>
                   {/* Mount Heatmap only when the scrobbles are set */}
-                  {this.state.scrobbles && (
+                  {this.state.scrobbles.length < this.state.pages && (
+                    <Loading pages={this.state.scrobbles.length} total={this.state.pages} />
+                  )}
+                  {this.state.scrobbles.length >= this.state.pages && (
                     <Heatmap title="Heatmap" user={this.state} />
                   )}
                 </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a solution to #11 
This implements a loading page that indicates the number of pages to fetch, and the number of pages fetched. It also makes a time estimation in seconds about the remaining time.


## Motivation and Context
When we added `.transition()` to `d3` elements `.attr()` changes, the animations looked laggy. This was because after every fetch, they would be re-drawn. 
Now all the animations are run at the same time, only once. This looks smoother, cleaner, and way more pleasing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Repeated use.

## Screenshots (if appropriate):

![Screenshot_20190705_083452](https://user-images.githubusercontent.com/22549761/60725890-ccb87300-9eff-11e9-912c-87b931d10055.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code maintainance (non-breaking change that makes existing code better)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the changelog accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
