### PR TITLE
Allow CSV file uploads and update the CSV with latest user scrobbles

### DIFF
--- a/src/components/upload/Upload.tsx
+++ b/src/components/upload/Upload.tsx
@@ -1,10 +1,12 @@
 import { useAppDispatch } from "@hooks";
+import { getUserInfo } from "api/lastfm";
 import classNames from "classnames/bind";
-import { Track } from "models/ScrobblePage";
+import { setUser } from "components/username/userSlice";
+import { SimplifiedTrack } from "models/ScrobblePage";
 import * as Papa from "papaparse";
 import { useEffect, useRef, useState } from "react";
 import styles from "./Upload.module.scss";
-import { setScrobbles } from "./uploadSlice";
+import { setSimplifiedTracks } from "./uploadSlice";
 
 let cx = classNames.bind(styles);
 
@@ -24,11 +26,19 @@ function Upload() {
 
     setIsProcessing(true);
 
-    Papa.parse<Track>(uploadedFile, {
+    // TODO: Add modal to confirm username before actually setting it in app state
+    const username = uploadedFile.name
+      // Remove file extension
+      .replace(/\.\w+$/, "")
+      // Remove everything after first space
+      .replace(/\s.*/, "");
+    getUserInfo(username).then((user) => dispatch(setUser(user)));
+
+    Papa.parse<SimplifiedTrack>(uploadedFile, {
       header: true,
       complete: ({ data }) => {
         setIsProcessing(false);
-        dispatch(setScrobbles(data));
+        dispatch(setSimplifiedTracks(data));
       },
     });
   }, [dispatch, uploadedFile, setIsProcessing]);

--- a/src/components/upload/Upload.tsx
+++ b/src/components/upload/Upload.tsx
@@ -1,12 +1,12 @@
 import { useAppDispatch } from "@hooks";
-import { getUserInfo } from "api/lastfm";
+import { getScrobbles, getUserInfo } from "api/lastfm";
 import classNames from "classnames/bind";
 import { setUser } from "components/username/userSlice";
 import { SimplifiedTrack } from "models/ScrobblePage";
 import * as Papa from "papaparse";
 import { useEffect, useRef, useState } from "react";
 import styles from "./Upload.module.scss";
-import { setSimplifiedTracks } from "./uploadSlice";
+import { addTracks, setSimplifiedTracks } from "./uploadSlice";
 
 let cx = classNames.bind(styles);
 
@@ -15,8 +15,6 @@ const ACCEPTED_CSV_FILES = ["text/csv", ".csv"];
 function Upload() {
   const [uploadedFile, setUploadedFile] = useState<File>();
 
-  const [isProcessing, setIsProcessing] = useState(false);
-
   const dispatch = useAppDispatch();
 
   useEffect(() => {
@@ -24,24 +22,71 @@ function Upload() {
       return;
     }
 
-    setIsProcessing(true);
-
     // TODO: Add modal to confirm username before actually setting it in app state
     const username = uploadedFile.name
       // Remove file extension
       .replace(/\.\w+$/, "")
       // Remove everything after first space
       .replace(/\s.*/, "");
-    getUserInfo(username).then((user) => dispatch(setUser(user)));
+    const userPromise = getUserInfo(username).then((user) =>
+      dispatch(setUser(user))
+    );
 
-    Papa.parse<SimplifiedTrack>(uploadedFile, {
-      header: true,
-      complete: ({ data }) => {
-        setIsProcessing(false);
-        dispatch(setSimplifiedTracks(data));
-      },
-    });
-  }, [dispatch, uploadedFile, setIsProcessing]);
+    const parsePromise = new Promise<SimplifiedTrack[]>((resolve, reject) =>
+      Papa.parse<SimplifiedTrack>(uploadedFile, {
+        header: true,
+        complete: ({ data }) => {
+          dispatch(setSimplifiedTracks(data));
+          resolve(data);
+        },
+        error: (error) => {
+          console.error(error);
+          reject(error);
+        },
+      })
+    );
+
+    Promise.all([parsePromise, userPromise]).then(
+      ([tracks, { payload: user }]) => {
+        const playcount = +user.playcount;
+
+        if (playcount === tracks.length) {
+          return;
+        }
+
+        // TODO: Consider the case of playcount < tracks.length, which should be incorrect
+
+        if (playcount > tracks.length) {
+          console.log("File is outdated, starting to fetch last scrobbles");
+        }
+        const diff = user.playcount - tracks.length;
+
+        const promises: Promise<void>[] = [];
+        const pageSize = 80;
+        const pages = Math.ceil(diff / pageSize);
+
+        for (let i = 0; i < pages; i++) {
+          promises.push(
+            getScrobbles(user.name, i + 1, pageSize)
+              .then((tracks) => {
+                if (tracks[0]["@attr"]?.nowplaying) {
+                  tracks.shift();
+                }
+
+                if (i * pageSize + (diff % pageSize) >= diff) {
+                  tracks.splice(diff % pageSize);
+                }
+
+                dispatch(addTracks(tracks));
+              })
+              // TODO: Add handling for rejected requests, so they can be retried
+              .catch((error) => console.error(error))
+          );
+        }
+        console.log({ pages });
+      }
+    );
+  }, [dispatch, uploadedFile]);
 
   const uploadFileRef = useRef<HTMLInputElement>(null);
 

--- a/src/components/upload/uploadSlice.ts
+++ b/src/components/upload/uploadSlice.ts
@@ -18,11 +18,17 @@ export const scrobbleDataSlice = createSlice({
   name: "scrobbleData",
   initialState,
   reducers: {
-    setScrobbles: (state, action: PayloadAction<Track[]>) => {
+    setSimplifiedTracks: (state, action: PayloadAction<SimplifiedTrack[]>) => {
+      state.value = action.payload;
+    },
+    addSimplifiedTracks: (state, action: PayloadAction<SimplifiedTrack[]>) => {
+      state.value = [...state.value, ...action.payload];
+    },
+    setTracks: (state, action: PayloadAction<Track[]>) => {
       const tracks: SimplifiedTrack[] = action.payload.map(SimplifiedTrack);
       state.value = tracks;
     },
-    addScrobbles: (state, action: PayloadAction<Track[]>) => {
+    addTracks: (state, action: PayloadAction<Track[]>) => {
       const tracks: SimplifiedTrack[] = action.payload.map(SimplifiedTrack);
       state.value = [...state.value, ...tracks];
     },
@@ -32,8 +38,13 @@ export const scrobbleDataSlice = createSlice({
   },
 });
 
-export const { setScrobbles, addScrobbles, setByDay } =
-  scrobbleDataSlice.actions;
+export const {
+  setSimplifiedTracks,
+  addSimplifiedTracks,
+  setTracks,
+  addTracks,
+  setByDay,
+} = scrobbleDataSlice.actions;
 
 // The function below is called a selector and allows us to select a value from
 // the state. Selectors can also be defined inline where they're used instead of

--- a/src/components/username/Username.tsx
+++ b/src/components/username/Username.tsx
@@ -1,11 +1,11 @@
 import { useAppDispatch } from "@hooks";
 import { getScrobbles, getUserInfo } from "api/lastfm";
 import classNames from "classnames/bind";
-import { addScrobbles } from "components/upload/uploadSlice";
+import { addTracks } from "components/upload/uploadSlice";
 import { User } from "models/User";
 import { FormEvent, useRef, useState } from "react";
 import styles from "./Username.module.scss";
-import { setUsername as setUsernameRedux } from "./userSlice";
+import { setUser as setUsernameRedux } from "./userSlice";
 
 const cx = classNames.bind(styles);
 
@@ -41,7 +41,7 @@ function UsernameInput() {
               if (tracks[0]["@attr"]?.nowplaying) {
                 tracks.shift();
               }
-              dispatch(addScrobbles(tracks));
+              dispatch(addTracks(tracks));
             })
             // TODO: Add handling for rejected requests, so they can be retried
             .catch((error) => console.error(error))

--- a/src/components/username/userSlice.ts
+++ b/src/components/username/userSlice.ts
@@ -16,13 +16,13 @@ export const userSlice = createSlice({
   name: "username",
   initialState,
   reducers: {
-    setUsername: (state, action: PayloadAction<User>) => {
+    setUser: (state, action: PayloadAction<User>) => {
       state.value = action.payload;
     },
   },
 });
 
-export const { setUsername } = userSlice.actions;
+export const { setUser } = userSlice.actions;
 
 // The function below is called a selector and allows us to select a value from
 // the state. Selectors can also be defined inline where they're used instead of


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds a working workflow for the CSV File upload functionality.
After uploading the CSV, it'll:
- read the filename, and guess the username,
- create the scrobbles list

Then it'll compare the user playcount, and the scrobbles list size. If they don't match, it'll calculate the number of pages left to complete the list and update it in the app. Allowing the user to re-download an up-to-date CSV.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prevent stressing the last.fm API.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code maintainance (non-breaking change that makes existing code better)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
